### PR TITLE
World map dumper chunk sprite fix 2

### DIFF
--- a/cache/src/main/java/net/runelite/cache/MapImageDumper.java
+++ b/cache/src/main/java/net/runelite/cache/MapImageDumper.java
@@ -1504,9 +1504,8 @@ public class MapImageDumper
 							ObjectDefinition object = findObject(location.getId());
 
 							int drawX = (drawBaseX + localX) * MAP_SCALE;
-							//What is offsetY?
-							int objSizeOffset = Math.max(2, object.getOffsetY());
-							int drawY = (drawBaseY + (Region.Y - objSizeOffset - localY)) * MAP_SCALE;
+							int objSizeOffset = Math.max(object.getSizeX(), object.getSizeY()) / 2;
+							int drawY = (drawBaseY + (Region.Y - objSizeOffset - localY - 1)) * MAP_SCALE;
 							if (object.getMapSceneID() != -1)
 							{
 								blitMapDecoration(image, drawX, drawY, object);

--- a/cache/src/main/java/net/runelite/cache/MapImageDumper.java
+++ b/cache/src/main/java/net/runelite/cache/MapImageDumper.java
@@ -1835,7 +1835,7 @@ public class MapImageDumper
 	{
 		SpriteDefinition sprite = mapDecorations[object.getMapSceneID()];
 		float scale = MAP_SCALE / (float) 4;
-		blitIcon(dst, x, y + MAP_SCALE, sprite, scale);
+		blitIcon(dst, x, y, sprite, scale);
 	}
 
 	private void blitIcon(BufferedImage dst, int x, int y, SpriteDefinition sprite, float scale)


### PR DESCRIPTION
I ditched using the "offsetY" property, I'm not really sure what it does, nor does whoever added that comment in the code, and it only appears for `mapSceneId`s 6 (dead tree), 64 (portal), and 81 (item red dot). Instead I used the object's tile size (1x1, 3x3, etc) to add a y-offset. I also added an extra 1 tile offset.  Here are some before/afters:

![0_33_46](https://github.com/user-attachments/assets/3728ec17-c9de-475b-86f3-741e62325b07) ![0_33_46](https://github.com/user-attachments/assets/f61148cf-987c-470e-9580-263447169ba9)
Just an example with a variety of sprites

![0_50_50](https://github.com/user-attachments/assets/51e1af00-ae29-4544-aa81-787cc0ead4c2) ![0_50_50](https://github.com/user-attachments/assets/7fb8ecc1-5ac5-4aaa-ab94-6309a03eb025)
Notice ladders and fountains

![1_50_50](https://github.com/user-attachments/assets/624000ab-e457-44ee-b1f9-31830a57902d) ![1_50_50](https://github.com/user-attachments/assets/37fe5286-9e1f-4be7-b325-7653c408891a)
Red dot

![0_45_54](https://github.com/user-attachments/assets/ebdedae8-68cb-48bb-8789-b191c2e633f0) ![0_45_54](https://github.com/user-attachments/assets/a2b00fce-acee-4d5b-a72f-1c8fe68a4f45)
This one gives me some pause, because the stonehenge things do look worse. But the portal looks better.

![0_46_50](https://github.com/user-attachments/assets/3775dce9-0397-4ceb-9a09-87c499016a4a) ![0_46_50](https://github.com/user-attachments/assets/250f9538-7903-4264-93d7-f19eb7685670)
House portal

![0_34_51](https://github.com/user-attachments/assets/f231d6e6-6e0a-47bd-acbf-f20b36be5600) ![0_34_51](https://github.com/user-attachments/assets/e398c22c-e2da-4499-b8de-f090c2a1c292)
Trees